### PR TITLE
Deprecate this auth module

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@ fcrepo-module-auth-xacml
 
 [![Build Status](https://travis-ci.org/fcrepo4/fcrepo-module-auth-xacml.png?branch=master)](https://travis-ci.org/fcrepo4/fcrepo-module-auth-xacml)
 
+### WARNING
+---
+
+_**This authorization module is deprecated and will be moved to [fcrepo4-archive](https://github.com/fcrepo4-archive)**_
+
+---
+
 XACML Authorization Delegate Module for the Fedora 4 Repository
 
 This module is based on the design documented here:

--- a/src/main/java/org/fcrepo/auth/xacml/XACMLAuthorizationDelegate.java
+++ b/src/main/java/org/fcrepo/auth/xacml/XACMLAuthorizationDelegate.java
@@ -44,6 +44,7 @@ import org.springframework.stereotype.Component;
  * @author Gregory Jansen
  */
 @Component("fad")
+@Deprecated
 public class XACMLAuthorizationDelegate extends AbstractRolesAuthorizationDelegate {
 
     public static final String EVERYONE_NAME = "EVERYONE";
@@ -123,6 +124,11 @@ public class XACMLAuthorizationDelegate extends AbstractRolesAuthorizationDelega
                                        final String absPath,
                                        final String[] actions,
                                        final Set<String> roles) {
+        LOGGER.warn("===========================");
+        LOGGER.warn("This authorization provider is deprecated and will be removed in a future release of Fedora: {}",
+                this.getClass());
+        LOGGER.warn("===========================");
+
         final EvaluationCtx evaluationCtx = buildEvaluationContext(session, absPath, actions, roles);
         final ResponseCtx resp = pdp.evaluate(evaluationCtx);
 


### PR DESCRIPTION
* Add note to README
* Add warning message whenever authorization delegate is invoked

Resolves: https://jira.duraspace.org/browse/FCREPO-2528

# To test
* Changes to fcrepo-webapp-plus must be made to enable the use of the auth module
** Guidance: https://gist.github.com/awoods/08e3473031b3883fe9e446268e46c769
* This PR must be built locally
* The updated fcrepo-webapp-plus must be built along the lines of:
```bash
mvn clean install -Pxacml -DskipTests
```
* Run fcrepo-webapp-plus
```bash
mvn -Dfcrepo.modeshape.configuration=classpath:/config/servlet-auth/repository.json  jetty:run -Pxacml
```
* Test
```
curl -i -uuser1:password1 localhost:8080/rest/
```